### PR TITLE
画面遷移間でのデータの受け渡しの実装+送信データの変換

### DIFF
--- a/lib/select_prefecture/select_chubu.dart
+++ b/lib/select_prefecture/select_chubu.dart
@@ -35,7 +35,9 @@ class SelectChubu extends StatelessWidget {
                         Navigator.push(
                           context,
                           MaterialPageRoute(
-                            builder: (context) => const SelectTerms(),
+                            builder: (context) => const SelectTerms(
+                              region: '新潟県',
+                            ),
                           ),
                         );
                       },
@@ -66,7 +68,9 @@ class SelectChubu extends StatelessWidget {
                         Navigator.push(
                           context,
                           MaterialPageRoute(
-                            builder: (context) => const SelectTerms(),
+                            builder: (context) => const SelectTerms(
+                              region: '富山県',
+                            ),
                           ),
                         );
                       },
@@ -97,7 +101,9 @@ class SelectChubu extends StatelessWidget {
                         Navigator.push(
                           context,
                           MaterialPageRoute(
-                            builder: (context) => const SelectTerms(),
+                            builder: (context) => const SelectTerms(
+                              region: '石川県',
+                            ),
                           ),
                         );
                       },
@@ -128,7 +134,9 @@ class SelectChubu extends StatelessWidget {
                         Navigator.push(
                           context,
                           MaterialPageRoute(
-                            builder: (context) => const SelectTerms(),
+                            builder: (context) => const SelectTerms(
+                              region: '福井県',
+                            ),
                           ),
                         );
                       },
@@ -159,7 +167,9 @@ class SelectChubu extends StatelessWidget {
                         Navigator.push(
                           context,
                           MaterialPageRoute(
-                            builder: (context) => const SelectTerms(),
+                            builder: (context) => const SelectTerms(
+                              region: '山梨県',
+                            ),
                           ),
                         );
                       },
@@ -190,7 +200,9 @@ class SelectChubu extends StatelessWidget {
                         Navigator.push(
                           context,
                           MaterialPageRoute(
-                            builder: (context) => const SelectTerms(),
+                            builder: (context) => const SelectTerms(
+                              region: '長野県',
+                            ),
                           ),
                         );
                       },
@@ -221,7 +233,9 @@ class SelectChubu extends StatelessWidget {
                         Navigator.push(
                           context,
                           MaterialPageRoute(
-                            builder: (context) => const SelectTerms(),
+                            builder: (context) => const SelectTerms(
+                              region: '岐阜県',
+                            ),
                           ),
                         );
                       },
@@ -252,7 +266,9 @@ class SelectChubu extends StatelessWidget {
                         Navigator.push(
                           context,
                           MaterialPageRoute(
-                            builder: (context) => const SelectTerms(),
+                            builder: (context) => const SelectTerms(
+                              region: '静岡県',
+                            ),
                           ),
                         );
                       },
@@ -283,7 +299,9 @@ class SelectChubu extends StatelessWidget {
                         Navigator.push(
                           context,
                           MaterialPageRoute(
-                            builder: (context) => const SelectTerms(),
+                            builder: (context) => const SelectTerms(
+                              region: '愛知県',
+                            ),
                           ),
                         );
                       },

--- a/lib/select_prefecture/select_chugoku.dart
+++ b/lib/select_prefecture/select_chugoku.dart
@@ -35,7 +35,9 @@ class SelectChugoku extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) => const SelectTerms(),
+                        builder: (context) => const SelectTerms(
+                          region: '鳥取県',
+                        ),
                       ),
                     );
                   },
@@ -66,7 +68,9 @@ class SelectChugoku extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) => const SelectTerms(),
+                        builder: (context) => const SelectTerms(
+                          region: '島根県',
+                        ),
                       ),
                     );
                   },
@@ -97,7 +101,9 @@ class SelectChugoku extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) => const SelectTerms(),
+                        builder: (context) => const SelectTerms(
+                          region: '岡山県',
+                        ),
                       ),
                     );
                   },
@@ -128,7 +134,9 @@ class SelectChugoku extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) => const SelectTerms(),
+                        builder: (context) => const SelectTerms(
+                          region: '広島県',
+                        ),
                       ),
                     );
                   },
@@ -159,7 +167,9 @@ class SelectChugoku extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) => const SelectTerms(),
+                        builder: (context) => const SelectTerms(
+                          region: '山口県',
+                        ),
                       ),
                     );
                   },

--- a/lib/select_prefecture/select_kanto.dart
+++ b/lib/select_prefecture/select_kanto.dart
@@ -35,7 +35,9 @@ class SelectKanto extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) => const SelectTerms(),
+                        builder: (context) => const SelectTerms(
+                          region: '茨城県',
+                        ),
                       ),
                     );
                   },
@@ -66,7 +68,9 @@ class SelectKanto extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) => const SelectTerms(),
+                        builder: (context) => const SelectTerms(
+                          region: '栃木県',
+                        ),
                       ),
                     );
                   },
@@ -97,7 +101,9 @@ class SelectKanto extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) => const SelectTerms(),
+                        builder: (context) => const SelectTerms(
+                          region: '群馬県',
+                        ),
                       ),
                     );
                   },
@@ -128,7 +134,9 @@ class SelectKanto extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) => const SelectTerms(),
+                        builder: (context) => const SelectTerms(
+                          region: '埼玉県',
+                        ),
                       ),
                     );
                   },
@@ -159,7 +167,9 @@ class SelectKanto extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) => const SelectTerms(),
+                        builder: (context) => const SelectTerms(
+                          region: '千葉県',
+                        ),
                       ),
                     );
                   },
@@ -190,7 +200,9 @@ class SelectKanto extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) => const SelectTerms(),
+                        builder: (context) => const SelectTerms(
+                          region: '東京都',
+                        ),
                       ),
                     );
                   },
@@ -202,7 +214,7 @@ class SelectKanto extends StatelessWidget {
                     ),
                   ),
                   child: const Text(
-                    '東京県',
+                    '東京都',
                     style: TextStyle(
                       color: Colors.black,
                       fontSize: 16,
@@ -221,7 +233,9 @@ class SelectKanto extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) => const SelectTerms(),
+                        builder: (context) => const SelectTerms(
+                          region: '神奈川県',
+                        ),
                       ),
                     );
                   },

--- a/lib/select_prefecture/select_kinki.dart
+++ b/lib/select_prefecture/select_kinki.dart
@@ -35,7 +35,9 @@ class SelectKinki extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) => const SelectTerms(),
+                        builder: (context) => const SelectTerms(
+                          region: '三重県',
+                        ),
                       ),
                     );
                   },
@@ -66,7 +68,9 @@ class SelectKinki extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) => const SelectTerms(),
+                        builder: (context) => const SelectTerms(
+                          region: '滋賀県',
+                        ),
                       ),
                     );
                   },
@@ -97,7 +101,9 @@ class SelectKinki extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) => const SelectTerms(),
+                        builder: (context) => const SelectTerms(
+                          region: '京都府',
+                        ),
                       ),
                     );
                   },
@@ -109,7 +115,7 @@ class SelectKinki extends StatelessWidget {
                     ),
                   ),
                   child: const Text(
-                    '京都県',
+                    '京都府',
                     style: TextStyle(
                       color: Colors.black,
                       fontSize: 16,
@@ -128,7 +134,9 @@ class SelectKinki extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) => const SelectTerms(),
+                        builder: (context) => const SelectTerms(
+                          region: '大阪県',
+                        ),
                       ),
                     );
                   },
@@ -159,7 +167,9 @@ class SelectKinki extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) => const SelectTerms(),
+                        builder: (context) => const SelectTerms(
+                          region: '兵庫県',
+                        ),
                       ),
                     );
                   },
@@ -190,7 +200,9 @@ class SelectKinki extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) => const SelectTerms(),
+                        builder: (context) => const SelectTerms(
+                          region: '奈良県',
+                        ),
                       ),
                     );
                   },
@@ -221,7 +233,9 @@ class SelectKinki extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) => const SelectTerms(),
+                        builder: (context) => const SelectTerms(
+                          region: '和歌山県',
+                        ),
                       ),
                     );
                   },

--- a/lib/select_prefecture/select_kyushu.dart
+++ b/lib/select_prefecture/select_kyushu.dart
@@ -35,7 +35,9 @@ class SelectKyushu extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) => const SelectTerms(),
+                        builder: (context) => const SelectTerms(
+                          region: '福岡県',
+                        ),
                       ),
                     );
                   },
@@ -66,7 +68,9 @@ class SelectKyushu extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) => const SelectTerms(),
+                        builder: (context) => const SelectTerms(
+                          region: '佐賀県',
+                        ),
                       ),
                     );
                   },
@@ -97,7 +101,9 @@ class SelectKyushu extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) => const SelectTerms(),
+                        builder: (context) => const SelectTerms(
+                          region: '長崎県',
+                        ),
                       ),
                     );
                   },
@@ -128,7 +134,9 @@ class SelectKyushu extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) => const SelectTerms(),
+                        builder: (context) => const SelectTerms(
+                          region: '熊本県',
+                        ),
                       ),
                     );
                   },
@@ -159,7 +167,9 @@ class SelectKyushu extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) => const SelectTerms(),
+                        builder: (context) => const SelectTerms(
+                          region: '大分県',
+                        ),
                       ),
                     );
                   },
@@ -190,7 +200,9 @@ class SelectKyushu extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) => const SelectTerms(),
+                        builder: (context) => const SelectTerms(
+                          region: '宮崎県',
+                        ),
                       ),
                     );
                   },
@@ -221,7 +233,9 @@ class SelectKyushu extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) => const SelectTerms(),
+                        builder: (context) => const SelectTerms(
+                          region: '鹿児島県',
+                        ),
                       ),
                     );
                   },
@@ -252,7 +266,9 @@ class SelectKyushu extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) => const SelectTerms(),
+                        builder: (context) => const SelectTerms(
+                          region: '沖縄県',
+                        ),
                       ),
                     );
                   },

--- a/lib/select_prefecture/select_shikoku.dart
+++ b/lib/select_prefecture/select_shikoku.dart
@@ -35,7 +35,7 @@ class SelectShikoku extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) => const SelectTerms(),
+                        builder: (context) => const SelectTerms(region: '香川県'),
                       ),
                     );
                   },
@@ -66,7 +66,9 @@ class SelectShikoku extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) => const SelectTerms(),
+                        builder: (context) => const SelectTerms(
+                          region: '徳島県',
+                        ),
                       ),
                     );
                   },
@@ -97,7 +99,9 @@ class SelectShikoku extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) => const SelectTerms(),
+                        builder: (context) => const SelectTerms(
+                          region: '愛媛県',
+                        ),
                       ),
                     );
                   },
@@ -128,7 +132,9 @@ class SelectShikoku extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) => const SelectTerms(),
+                        builder: (context) => const SelectTerms(
+                          region: '高知県',
+                        ),
                       ),
                     );
                   },

--- a/lib/select_prefecture/select_tohoku.dart
+++ b/lib/select_prefecture/select_tohoku.dart
@@ -35,7 +35,9 @@ class SelectTohoku extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) => const SelectTerms(),
+                        builder: (context) => const SelectTerms(
+                          region: '青森県',
+                        ),
                       ),
                     );
                   },
@@ -66,7 +68,9 @@ class SelectTohoku extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) => const SelectTerms(),
+                        builder: (context) => const SelectTerms(
+                          region: '岩手県',
+                        ),
                       ),
                     );
                   },
@@ -97,7 +101,9 @@ class SelectTohoku extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) => const SelectTerms(),
+                        builder: (context) => const SelectTerms(
+                          region: '宮城県',
+                        ),
                       ),
                     );
                   },
@@ -128,7 +134,9 @@ class SelectTohoku extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) => const SelectTerms(),
+                        builder: (context) => const SelectTerms(
+                          region: '秋田県',
+                        ),
                       ),
                     );
                   },
@@ -159,7 +167,9 @@ class SelectTohoku extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) => const SelectTerms(),
+                        builder: (context) => const SelectTerms(
+                          region: '山形県',
+                        ),
                       ),
                     );
                   },
@@ -190,7 +200,9 @@ class SelectTohoku extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) => const SelectTerms(),
+                        builder: (context) => const SelectTerms(
+                          region: '福島県',
+                        ),
                       ),
                     );
                   },

--- a/lib/select_region.dart
+++ b/lib/select_region.dart
@@ -41,7 +41,9 @@ class SelectRegion extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) => const SelectTerms(),
+                        builder: (context) => const SelectTerms(
+                          region: "北海道",
+                        ),
                       ),
                     );
                   },

--- a/lib/select_terms.dart
+++ b/lib/select_terms.dart
@@ -69,30 +69,82 @@ class _SelectComponent extends StatefulWidget {
   State<_SelectComponent> createState() => _SelectComponentState();
 }
 
-//TODO：フロントで返す値を逆にする（5は雨が降る方が良い、になってる）
 class _SelectComponentState extends State<_SelectComponent> {
+  // バー用の変数
   double rain = 0.0;
   double temperatureHight = 0.0;
   double temperatureLow = 0.0;
   double security = 0.0;
+  // サーバーに送る用の保存用変数
+  double rainValue = 0.0;
+  double temperatureHightValue = 0.0;
+  double temperatureLowValue = 0.0;
+  double securityValue = 0.0;
 
-  // 最初に一度だけ実行される
-  // 始めの値が0か確認している
-  @override
-  void initState() {
-    super.initState();
-    valueChanged();
-  }
-
-  // 値が変わったかどうか確認する関数
+  // 値をサーバーに適した形にする関数+送信もかねている
   // ボタンを押したときに実行するようになっている
   //　APIとの繋ぎで使用する
   void valueChanged() {
-    debugPrint(rain.toString());
-    debugPrint(temperatureHight.toString());
-    debugPrint(temperatureLow.toString());
-    debugPrint(security.toString());
+    if (rain == 0.0) {
+      rainValue = 5.0;
+    } else if (rain == 1.0) {
+      rainValue = 4.0;
+    } else if (rain == 2.0) {
+      rainValue = 3.0;
+    } else if (rain == 3.0) {
+      rainValue = 2.0;
+    } else if (rain == 4.0) {
+      rainValue = 1.0;
+    } else if (rain == 5.0) {
+      rainValue = 0.0;
+    }
+    if (temperatureHight == 0.0) {
+      temperatureHightValue = 5.0;
+    } else if (temperatureHight == 1.0) {
+      temperatureHightValue = 4.0;
+    } else if (temperatureHight == 2.0) {
+      temperatureHightValue = 3.0;
+    } else if (temperatureHight == 3.0) {
+      temperatureHightValue = 2.0;
+    } else if (temperatureHight == 4.0) {
+      temperatureHightValue = 1.0;
+    } else if (temperatureHight == 5.0) {
+      temperatureHightValue = 0.0;
+    }
+
+    if (temperatureLow == 0.0) {
+      temperatureLowValue = 5.0;
+    } else if (temperatureLow == 1.0) {
+      temperatureLowValue = 4.0;
+    } else if (temperatureLow == 2.0) {
+      temperatureLowValue = 3.0;
+    } else if (temperatureLow == 3.0) {
+      temperatureLowValue = 2.0;
+    } else if (temperatureLow == 4.0) {
+      temperatureLowValue = 1.0;
+    } else if (temperatureLow == 5.0) {
+      temperatureLow = 0.0;
+    }
+    if (security == 0.0) {
+      securityValue = 5.0;
+    } else if (security == 1.0) {
+      securityValue = 4.0;
+    } else if (security == 2.0) {
+      securityValue = 3.0;
+    } else if (security == 3.0) {
+      securityValue = 2.0;
+    } else if (security == 4.0) {
+      securityValue = 1.0;
+    } else if (security == 5.0) {
+      securityValue = 0.0;
+    }
+    debugPrint(rainValue.toString());
+    debugPrint(temperatureHightValue.toString());
+    debugPrint(temperatureLowValue.toString());
+    debugPrint(securityValue.toString());
     debugPrint(widget.region);
+
+    setState(() {});
   }
 
   @override

--- a/lib/select_terms.dart
+++ b/lib/select_terms.dart
@@ -1,18 +1,25 @@
 import 'package:flutter/material.dart';
 
 class SelectTerms extends StatelessWidget {
-  const SelectTerms({super.key});
+  final String region;
+  // ignore: use_key_in_widget_constructors
+  const SelectTerms({required this.region});
 
   @override
   Widget build(BuildContext context) {
-    return const SizedBox(child: MainPage(title: '見つけld'));
+    return SizedBox(
+        child: MainPage(
+      title: '見つけld',
+      region: region,
+    ));
   }
 }
 
 class MainPage extends StatefulWidget {
-  const MainPage({super.key, required this.title});
+  const MainPage({super.key, required this.title, required this.region});
 
   final String title;
+  final String region;
 
   @override
   State<MainPage> createState() => _MainState();
@@ -45,7 +52,9 @@ class _MainState extends State<MainPage> {
             const SizedBox(
               height: 32,
             ),
-            _SelectComponent()
+            _SelectComponent(
+              region: widget.region,
+            )
           ],
         ),
       ),
@@ -54,6 +63,8 @@ class _MainState extends State<MainPage> {
 }
 
 class _SelectComponent extends StatefulWidget {
+  const _SelectComponent({required this.region});
+  final String region;
   @override
   State<_SelectComponent> createState() => _SelectComponentState();
 }
@@ -75,12 +86,13 @@ class _SelectComponentState extends State<_SelectComponent> {
 
   // 値が変わったかどうか確認する関数
   // ボタンを押したときに実行するようになっている
-  //　APIとの繋ぎが出来たら削除する
+  //　APIとの繋ぎで使用する
   void valueChanged() {
     debugPrint(rain.toString());
     debugPrint(temperatureHight.toString());
     debugPrint(temperatureLow.toString());
     debugPrint(security.toString());
+    debugPrint(widget.region);
   }
 
   @override


### PR DESCRIPTION
- 検索ボタン画面に、何県を選択したか引き継げる実装をした
- サーバー側とアプリ側ではベクトルの表現が真逆なので、サーバーに送れるようにデータを変換できるようにした
- simulatorで確認OK